### PR TITLE
Remove h3 and replace h1 with h2 in subheadings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Issues
-### Any issues you may have with Cache such as a bug, error or you just need support.
-### Spam Issues will be ignored and removed
+Any issues you may have with Cache such as a bug, error or you just need support.
 
-# How to open an issue:
+Spam Issues will be ignored and removed
 
-### Start by locating the "Issues" tab.
+## How to open an issue:
+
+Start by locating the "Issues" tab.
 ![Tab](screenshots/tab.png)
 
-### Click the button below Marked "New Issue"
+Click the button below Marked "New Issue"
 ![Create](screenshots/create.png)
 
-### Now you will be given a page, make sure the title accuratly reflects the issue and that the description contains steps on how to replicate the issue and what the issue actually is
+Now you will be given a page, make sure the title accuratly reflects the issue and that the description contains steps on how to replicate the issue and what the issue actually is
 
 ![Dscribe](screenshots/describe.png)
 
-# Bear in Mind
-### Now you should await a response, please bear in mind developers may be slow to respond and we are not active 24/7 so please allow up to a week for the issue to be solved.
+## Bear in Mind
+Now you should await a response, please bear in mind developers may be slow to respond and we are not active 24/7 so please allow up to a week for the issue to be solved.


### PR DESCRIPTION
The h3s in the normal text kinda spammed the screen.  This PR removes them.

The subheadings now have h2 instead of h1.