### PR TITLE
Add issue template and fix readme

### DIFF
--- a/.github/ISSUE_TEMPLATE.MD
+++ b/.github/ISSUE_TEMPLATE.MD
@@ -1,0 +1,33 @@
+## Description
+<!-- Describe your issue here below this line. Please be as descriptive as possible -->
+
+## Checklist
+<!--
+  Mark the options that are relevant to issues with "x"
+  Just add an "x" inside the brackets [].
+
+  Example:
+    Before: - [ ] ...
+    After:  - [x] ...
+-->
+
+- [ ] This issue is a bug report.
+  - [ ] I have added Steps to Reproduce.
+
+- [ ] This issue is a feature request/improvement
+  - [ ] I have described my request briefly
+
+- [ ] This issue is something not mentioned here. I have described it.
+
+## The issue is about
+<!-- Whats the issue's related to? Choose from:
+  - Support server
+  - The bot itself
+  - Documentation
+  - Others (Please describe)
+
+Add text here after the arrow -->
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Issues
-### Any issues you may have with Cache such as a bug, error or you just need support.
-### Spam Issues will be ignored and removed
+Any issues you may have with Cache such as a bug, error or you just need support.
 
-# How to open an issue:
+Spam Issues will be ignored and removed
 
-### Start by locating the "Issues" tab.
+## How to open an issue:
+
+Start by locating the "Issues" tab.
 ![Tab](screenshots/tab.png)
 
-### Click the button below Marked "New Issue"
+Click the button below Marked "New Issue"
 ![Create](screenshots/create.png)
 
-### Now you will be given a page, make sure the title accuratly reflects the issue and that the description contains steps on how to replicate the issue and what the issue actually is
+Now you will be given a page, make sure the title accuratly reflects the issue and that the description contains steps on how to replicate the issue and what the issue actually is
 
 ![Dscribe](screenshots/describe.png)
 
-# Bear in Mind
-### Now you should await a response, please bear in mind developers may be slow to respond and we are not active 24/7 so please allow up to a week for the issue to be solved.
+## Bear in mind
+Now you should await a response, please bear in mind developers may be slow to respond and we are not active 24/7 so please allow up to a week for the issue to be solved.


### PR DESCRIPTION
This PR adds an issue template. Issue template will be shown to anyone who attempts to open an issue.

When someone clicks the "Open an issue" button, This template will automatically be filled in Description.

I added as many things as I could, If there's anything I missed in this template let me know.

## README change

The h3s in the normal text kinda spammed the screen. This PR removes them.

The subheadings now have h2 instead of h1.